### PR TITLE
Ignore unused arguments prefixed with an underscore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     },
     "rules": {
         "object-curly-newline": "off",
-        "camelcase": "off"
+        "camelcase": "off",
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
     }
 }

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const app = new App({
 });
 
 /** Sample Function Listener */
-app.function('sample_function', async ({ client, inputs, complete, fail }) => {
+app.function('sample_function', async ({ _client, inputs, complete, fail }) => {
   try {
     const { sample_input } = inputs;
 


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR adds a condition to the [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) linter rule to ignore errors for variables prefixed with an underscore.

Unfortunately the [`args-after-used`](https://eslint.org/docs/latest/rules/no-unused-vars#args-after-used) option doesn't apply to object parameters, so this is the best workaround I can think of. Open to other suggestions of course!

### Notes

- I'm hoping this `_client` remains clear that it corresponds to the commented `client`. But not so sure about this...

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
