### PR TITLE
Disable lint errors with no-console

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { App, LogLevel } = require('@slack/bolt');
 const { config } = require('dotenv');
 


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [X] Something else

### Summary

The goal of this PR is to improve the developer experience by ensuring there are no lint errors when this project is cloned. 

Specifically, this will ignore eslint errors around the educational usage of `console.error` in the listener and action callback functions by marking the whole file with `eslint-disable no-console`. 

**Alternatively** we could add the lint ignore comment to each invocation of `console.error()`.

### Requirements (place an x in each [ ] that applies)

- [X] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [X] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
