### PR TITLE
fix: remove the outgoing domains property from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,5 @@
                 }
             }
         }
-    },
-    "outgoing_domains": []
+    }
 }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR removes the `outgoing_domains` property from the `manifest.json` since this is not enforced at an application level and the CLI now supports installing apps without this property set.

### Reviewers

```sh
$ slack create asdf --template slack-samples/bolt-js-custom-function-template
$ cd asdf
$ slack run
```

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
