### PR TITLE
feat(deps): remove the dotenv configurations for environment variables

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,4 @@
 const { App, LogLevel } = require('@slack/bolt');
-const { config } = require('dotenv');
-
-config();
 
 /** Initialization */
 const app = new App({

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@slack/bolt": "3.17.1-customFunctionBeta.0",
-        "dotenv": "~16.4.5"
+        "@slack/bolt": "3.17.1-customFunctionBeta.0"
       },
       "devDependencies": {
         "@slack/cli-hooks": "^1.1.0",
@@ -944,17 +943,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "url": "https://github.com/slack-samples/bolt-js-custom-function-template/issues"
   },
   "dependencies": {
-    "@slack/bolt": "3.17.1-customFunctionBeta.0",
-    "dotenv": "~16.4.5"
+    "@slack/bolt": "3.17.1-customFunctionBeta.0"
   },
   "devDependencies": {
     "@slack/cli-hooks": "^1.1.0",


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR removes `dotenv` from the list of dependencies since the required environment variables `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN` are injected into the CLI `run` process on install.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
