### PR TITLE
fix: remove an unused process port for socket mode starts

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,12 +61,12 @@ app.action('sample_button', async ({ body, client, complete, fail }) => {
   }
 });
 
-/** Start Bolt App */
+/** Start the Bolt App */
 (async () => {
   try {
-    await app.start(process.env.PORT || 3000);
-    console.log('⚡️ Bolt app is running! ⚡️');
+    await app.start();
+    console.log('⚡️ Bolt app is running!');
   } catch (error) {
-    console.error('Unable to start App', error);
+    console.error('Failed to start the app', error);
   }
 })();


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

The `app.start()` doesn't need a `PORT` to connect with Socket Mode - removing it here to avoid confusion!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
